### PR TITLE
Postbuild event fixup

### DIFF
--- a/Injector/Injector.csproj
+++ b/Injector/Injector.csproj
@@ -58,7 +58,7 @@
     <PostBuildEvent>cd $(SolutionDir)MainGUI\
 mkdir Resources
 cd Resources
-"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 $(TargetFileName).gz $(ProjectDir)$(OutDir)$(TargetFileName)
-"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 Mono.Cecil.dll.gz $(ProjectDir)$(OutDir)Mono.Cecil.dll</PostBuildEvent>
+"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 "$(TargetFileName).gz" "$(ProjectDir)$(OutDir)$(TargetFileName)"
+"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 Mono.Cecil.dll.gz "$(ProjectDir)$(OutDir)Mono.Cecil.dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/ModLoader/ModLoader.csproj
+++ b/ModLoader/ModLoader.csproj
@@ -84,8 +84,8 @@
     <PostBuildEvent>cd $(SolutionDir)MainGUI\
 mkdir Resources
 cd Resources
-"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 $(TargetFileName).gz $(ProjectDir)$(OutDir)$(TargetFileName)
-"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 Newtonsoft.Json.dll.gz $(ProjectDir)$(OutDir)Newtonsoft.Json.dll
-"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 0Harmony.dll.gz $(ProjectDir)$(OutDir)0Harmony.dll</PostBuildEvent>
+"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 "$(TargetFileName).gz" "$(ProjectDir)$(OutDir)$(TargetFileName)"
+"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 Newtonsoft.Json.dll.gz "$(ProjectDir)$(OutDir)Newtonsoft.Json.dll"
+"c:\Program Files\7-Zip\7z.exe" a -bd -bb0 -tgzip -mx=0 -mfb=258 0Harmony.dll.gz "$(ProjectDir)$(OutDir)0Harmony.dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes an issue with the postbuild scripts where spaces in filepaths will break 7z's packing.